### PR TITLE
Permitir budget_id reciba valores nulos y actualización de movementsController

### DIFF
--- a/api/src/app/controllers/movementController.js
+++ b/api/src/app/controllers/movementController.js
@@ -17,7 +17,6 @@ router.get('/', (req, res) => {
     ],
   })
     .then((foundMovements) => {
-      console.log(foundMovements);
       const processedMovements = foundMovements.map((movement) => {
         const {
           id,

--- a/api/src/db/migrations/20210512052733-modify-service-category-join-table.js
+++ b/api/src/db/migrations/20210512052733-modify-service-category-join-table.js
@@ -11,7 +11,7 @@ module.exports = {
       }),
     ]);
   },
-
+  // eslint-disable-next-line no-unused-vars
   down(queryInterface, Sequelize) {
     return Promise.all([
       queryInterface.removeColumn('ServiceCategories', 'createdAt'),

--- a/api/src/db/migrations/20210514100930-modify-budget-allownull-property.js
+++ b/api/src/db/migrations/20210514100930-modify-budget-allownull-property.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: (queryInterface, Sequelize) =>
+    Promise.all([
+      queryInterface.changeColumn('Movements', 'budget_id', {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      }),
+    ]),
+
+  down: (queryInterface) => Promise.all([queryInterface.changeColumn('Movements', 'budget_id')]),
+};


### PR DESCRIPTION
Fix para permitir que la columna budget_id en la tabla Movements permita valores nulos cuando se realice un movimiento de tipo INCOME